### PR TITLE
[CHANGE] Use django-sri for hash calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Section Order:
 
 - Python 3.13 to the test matrix
 
+### Changed
+
+- Use `django-sri` for hash calculation
+
 ## [2.1.0] - 2024-09-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Section Order:
 ### Changed
 
 - Use `django-sri` for hash calculation
+- Minimum requirements
+  - Alliance Auth >= 4.6.0
 
 ## [2.1.0] - 2024-09-09
 

--- a/aa_theme_slate/constants.py
+++ b/aa_theme_slate/constants.py
@@ -1,0 +1,9 @@
+"""
+Constants used in this app
+"""
+
+# Standard Library
+import os
+
+SLATE_BASE_DIR = os.path.join(os.path.dirname(__file__))
+SLATE_STATIC_DIR = os.path.join(SLATE_BASE_DIR, "static", "aa_theme_slate")

--- a/aa_theme_slate/helper/static_files.py
+++ b/aa_theme_slate/helper/static_files.py
@@ -1,0 +1,85 @@
+"""
+Helper functions for static integrity calculations
+"""
+
+# Standard Library
+import os
+from pathlib import Path
+from urllib.parse import urljoin
+
+# Third Party
+from sri import Algorithm, calculate_integrity
+
+# Django
+from django.conf import settings
+
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
+
+# Alliance Auth (External Libs)
+from app_utils.logging import LoggerAddTag
+
+# AA Theme Slate
+from aa_theme_slate import __title__, __version__
+from aa_theme_slate.constants import SLATE_STATIC_DIR
+
+logger = LoggerAddTag(my_logger=get_extension_logger(__name__), prefix=__title__)
+
+
+def calculate_integrity_hash(relative_file_path: str) -> str:
+    """
+    Calculates the integrity hash for a given static file
+
+    :param self:
+    :type self:
+    :param relative_file_path: The file path relative to the `aa_theme_slate/static/aa_theme_slate` folder
+    :type relative_file_path: str
+    :return: The integrity hash
+    :rtype: str
+    """
+
+    file_path = os.path.join(SLATE_STATIC_DIR, relative_file_path)
+    integrity_hash = calculate_integrity(
+        path=Path(file_path), algorithm=Algorithm.SHA512
+    )
+
+    return integrity_hash
+
+
+def get_theme_hook_static(
+    static_file: str, script_type: str = None, with_version: bool = False
+) -> dict:
+    """
+    Get the static file details for a theme hook
+
+    :param static_file: The file path relative to the `aa_theme_slate/static/aa_theme_slate` folder
+    :type static_file: str
+    :param script_type: The script type
+    :type script_type: str
+    :param with_version: Includes the version number in the URL
+    :type with_version: bool
+    :return: The static file details
+    :rtype: dict
+    """
+
+    return_value = {
+        "url": urljoin(
+            base=settings.STATIC_URL,
+            url=f"aa_theme_slate/{static_file}",
+        ),
+    }
+
+    # Calculate integrity hash if not in debug mode
+    if not settings.DEBUG:
+        integrity = calculate_integrity_hash(relative_file_path=static_file)
+        return_value["integrity"] = integrity
+
+    # Add the script type if provided
+    if script_type:
+        return_value["js_type"] = script_type
+
+    # Add the version number if requested
+    if with_version:
+        return_value["url"] += f"?v={__version__}"
+
+    return return_value

--- a/aa_theme_slate/theme/slate/auth_hooks.py
+++ b/aa_theme_slate/theme/slate/auth_hooks.py
@@ -2,15 +2,12 @@
 Auth hooks for Slate Bootstrap Theme for Alliance Auth
 """
 
-# Standard Library
-from urllib.parse import urljoin
-
-# Django
-from django.conf import settings
-
 # Alliance Auth
 from allianceauth import hooks
 from allianceauth.theme.hooks import ThemeHook
+
+# AA Theme Slate
+from aa_theme_slate.helper.static_files import get_theme_hook_static
 
 
 class AaSlateThemeHook(ThemeHook):
@@ -24,43 +21,32 @@ class AaSlateThemeHook(ThemeHook):
         Init
         """
 
+        css_static_files = [
+            get_theme_hook_static(
+                static_file="theme/aav4/libs/bootswatch/v5.3.3/slate/css/bootstrap.min.css"
+            ),
+            get_theme_hook_static(
+                static_file="theme/aav4/css/community-apps.min.css",
+                with_version=True,
+            ),
+        ]
+
+        js_static_files = [
+            get_theme_hook_static(
+                static_file="theme/aav4/libs/popper/v2.11.8/popper.min.js"
+            ),
+            get_theme_hook_static(
+                static_file="theme/aav4/libs/bootswatch/v5.3.3/slate/javascript/bootstrap.min.js"
+            ),
+        ]
+
         ThemeHook.__init__(
             self=self,
             name="Slate",
             description="Slate Bootstrap Theme for Alliance Auth",
             html_tags={"data-theme": "slate"},
-            css=[
-                {
-                    "url": urljoin(
-                        base=settings.STATIC_URL,
-                        url="aa_theme_slate/theme/aav4/libs/bootswatch/v5.3.3/slate/css/bootstrap.min.css",
-                    ),
-                    "integrity": "sha512-lF+xS8uroqRohnQyVXSTrsB+YgYcwHKVm8T6atFzc/cnOW1RTnc6x00585jS74sz9GPrNbzH4QkP8JICSXNP0Q==",
-                },
-                {
-                    "url": urljoin(
-                        base=settings.STATIC_URL,
-                        url="aa_theme_slate/theme/aav4/css/community-apps.min.css",
-                    ),
-                    "integrity": "sha512-VBvK3DWVVD8A8QuA2cI01eBV7110vo7VPhdp1kbTi04NImoXO4nfIaXlUp90kLhQMtw9YnBYADTJ2Ldos79ihQ==",
-                },
-            ],
-            js=[
-                {
-                    "url": urljoin(
-                        base=settings.STATIC_URL,
-                        url="aa_theme_slate/theme/aav4/libs/popper/v2.11.8/popper.min.js",
-                    ),
-                    "integrity": "sha512-fhcY1KxngNJ4jVhZBdmrLv4/NH31jrNM45fpxytokYp06cd7Ug05E3gximUQmukhES9Xf0kbV5F1nHVqWq2bvQ==",
-                },
-                {
-                    "url": urljoin(
-                        base=settings.STATIC_URL,
-                        url="aa_theme_slate/theme/aav4/libs/bootswatch/v5.3.3/slate/javascript/bootstrap.min.js",
-                    ),
-                    "integrity": "sha512-gNyiMtmOs5iIO2fjMFZRSR1s9Espoi+fdDtNuSh1iMpeRminsho2AA7767qpfkYqskd9PtUfMwAg0KdKJsMTuQ==",
-                },
-            ],
+            css=css_static_files,
+            js=js_static_files,
             header_padding="3.6em",
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dynamic = [
 ]
 dependencies = [
     "allianceauth>=4.6,<5",
+    "allianceauth-app-utils>=1.25",
 ]
 optional-dependencies.tests-allianceauth-latest = [
     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth>=4.3,<5",
+    "allianceauth>=4.6,<5",
 ]
 optional-dependencies.tests-allianceauth-latest = [
     "coverage",


### PR DESCRIPTION
## Description

### Changed

- Use `django-sri` for hash calculation
- Minimum requirements
  - Alliance Auth >= 4.6.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
