### PR TITLE
[CHANGE] Use the new static files manifest storage provided by AA v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Section Order:
 
 - Missing `.map` files for the CSS and JS files
 
+### Changed
+
+- Use the new static files manifest storage backend provided by Alliance Auth v4.8.0
+- Minimum requirements
+  - Alliance Auth >= 4.8.0
+
 ## [2.2.0] - 2025-02-03
 
 ### Added

--- a/aa_theme_slate/constants.py
+++ b/aa_theme_slate/constants.py
@@ -1,9 +1,0 @@
-"""
-Constants used in this app
-"""
-
-# Standard Library
-import os
-
-SLATE_BASE_DIR = os.path.join(os.path.dirname(__file__))
-SLATE_STATIC_DIR = os.path.join(SLATE_BASE_DIR, "static", "aa_theme_slate")

--- a/aa_theme_slate/theme/slate/auth_hooks.py
+++ b/aa_theme_slate/theme/slate/auth_hooks.py
@@ -23,20 +23,19 @@ class AaSlateThemeHook(ThemeHook):
 
         css_static_files = [
             get_theme_hook_static(
-                static_file="theme/aav4/libs/bootswatch/v5.3.3/slate/css/bootstrap.min.css"
+                static_file="aa_theme_slate/theme/aav4/libs/bootswatch/v5.3.3/slate/css/bootstrap.min.css"
             ),
             get_theme_hook_static(
-                static_file="theme/aav4/css/community-apps.min.css",
-                with_version=True,
+                static_file="aa_theme_slate/theme/aav4/css/community-apps.min.css"
             ),
         ]
 
         js_static_files = [
             get_theme_hook_static(
-                static_file="theme/aav4/libs/popper/v2.11.8/popper.min.js"
+                static_file="aa_theme_slate/theme/aav4/libs/popper/v2.11.8/popper.min.js"
             ),
             get_theme_hook_static(
-                static_file="theme/aav4/libs/bootswatch/v5.3.3/slate/javascript/bootstrap.min.js"
+                static_file="aa_theme_slate/theme/aav4/libs/bootswatch/v5.3.3/slate/javascript/bootstrap.min.js"
             ),
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth>=4.6,<5",
+    "allianceauth>=4.8,<5",
     "allianceauth-app-utils>=1.25",
 ]
 optional-dependencies.tests-allianceauth-latest = [


### PR DESCRIPTION
## Description

### Changed

- Use the new static files manifest storage backend provided by Alliance Auth v4.8.0
- Minimum requirements
  - Alliance Auth >= 4.8.0

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
