### PR TITLE
[RELEASE] v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [2.4.0] - 2025-09-22
+
 ### Changed
 
 - Moved asset loading into a template instead of an `auth_hook`. This allows to load the assets only on pages where they are needed.
@@ -318,6 +320,7 @@ if "aa_theme_slate" in INSTALLED_APPS:
 [2.1.0]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.0.0...v2.1.0 "v2.1.0"
 [2.2.0]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.1.0...v2.2.0 "v2.2.0"
 [2.3.0]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.2.0...v2.3.0 "v2.3.0"
-[in development]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.3.0...HEAD "In Development"
+[2.4.0]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.3.0...v2.4.0 "v2.4.0"
+[in development]: https://github.com/ppfeufer/aa-theme-slate/compare/v2.4.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,11 @@ prepare-release:
 	echo "Updated version in $(TEXT_BOLD)$(package)/__init__.py$(TEXT_BOLD_END)"; \
 	if [[ $$new_version =~ (alpha|beta) ]]; then \
 		echo "$(TEXT_COLOR_RED)$(TEXT_BOLD)Pre-release$(TEXT_RESET) version detected!"; \
-		git restore $(translation_directory)/django.pot; \
 	else \
 		echo "$(TEXT_BOLD)Release$(TEXT_BOLD_END) version detected."; \
 		sed -i -E "/$(appname)==/s/==.*/==$$new_version/" README.md; \
 		sed -i -E "\|\[in development\]\: |s|\]\: .*|\]\: $(git_repository)/compare/v$$new_version...HEAD \"In Development\"|g" CHANGELOG.md; \
 		echo "Updated version in $(TEXT_BOLD)README.md$(TEXT_BOLD_END)"; \
-		sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$new_version\\\n\"" $(translation_template); \
-		sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template); \
 	fi;
 
 # Help

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ______________________________________________________________________
 > The last version of Alliance Auth Theme Slate that supports Alliance Auth v3 is `1.7.1`.
 
 ```shell
-pip install aa-theme-slate==2.3.0
+pip install aa-theme-slate==2.4.0
 ```
 
 Now open your `local.py` and add the following right below your `INSTALLED_APPS`:

--- a/aa_theme_slate/__init__.py
+++ b/aa_theme_slate/__init__.py
@@ -2,5 +2,5 @@
 Initialize the app
 """
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __title__ = 'Bootstrap Theme "Slate" for Alliance Auth'


### PR DESCRIPTION
## [2.4.0] - 2025-09-22

### Changed

- Moved asset loading into a template instead of an `auth_hook`. This allows to load the assets only on pages where they are needed.
- Minimum requirements
  - Alliance Auth >= 4.10.0
